### PR TITLE
feat(ui): add custom industrial 404 page

### DIFF
--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,54 @@
+import Link from 'next/link';
+import { AlertTriangle, Terminal, ArrowRight } from 'lucide-react';
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-bg-primary text-text font-mono p-6">
+      <div className="max-w-2xl w-full space-y-8">
+        {/* Header Section */}
+        <div className="flex flex-col items-center space-y-4">
+          <div className="flex items-center space-x-4 text-red-500 drop-shadow-[0_0_15px_rgba(239,68,68,0.5)]">
+            <AlertTriangle className="w-16 h-16 animate-pulse" />
+            <h1 className="text-8xl md:text-9xl font-black tracking-tighter">404</h1>
+          </div>
+          <h2 className="text-xl md:text-2xl text-text/80 uppercase tracking-widest text-center">
+            Page Not Found
+          </h2>
+        </div>
+
+        {/* System Log Panel */}
+        <div className="w-full border border-border bg-black/40 rounded-md p-6 relative overflow-hidden shadow-2xl">
+          <div className="absolute top-0 left-0 w-full h-1 bg-red-500/50"></div>
+          <div className="flex items-center space-x-2 text-text/50 mb-4 text-sm border-b border-border/50 pb-2">
+            <Terminal className="w-4 h-4" />
+            <span>syslog_tail.sh</span>
+          </div>
+          <div className="space-y-2 text-sm md:text-base text-text/80">
+            <p>
+              <span className="text-red-400 font-bold">[ERROR]</span> ERR_RESOURCE_NOT_LOCATED
+            </p>
+            <p>
+              <span className="text-blue-400 font-bold">[INFO]</span> Target endpoint does not exist
+              in the routing table.
+            </p>
+            <p>
+              <span className="text-yellow-400 font-bold">[WARN]</span> Please verify the URL or
+              return to the active monitoring console.
+            </p>
+          </div>
+        </div>
+
+        {/* Action Section */}
+        <div className="flex justify-center pt-4">
+          <Link
+            href="/dashboard"
+            className="glow-btn flex items-center space-x-2 px-6 py-3 border border-border rounded-md bg-transparent hover:bg-white/5 transition-all group"
+          >
+            <span>Return to Command Center</span>
+            <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Implemented a custom industrial-themed `404 Not Found` page for the web application.

### What was added

* Created `apps/web/app/not-found.tsx`
* Added a responsive custom 404 UI
* Used `lucide-react` icons for visual feedback
* Added a terminal/syslog styled error panel
* Added an animated warning section and CTA button
* Added navigation back to `/dashboard`
* Styled the page using existing theme utility classes

### Motivation

The default Next.js 404 page did not align with the application's industrial/cyber monitoring aesthetic. This implementation improves the user experience by providing a branded fallback page with clear navigation and consistent visual design.

Closes #9

---

## Type of Change

* [x] ✨ New feature (non-breaking change which adds functionality)

---

## How Has This Been Tested?

* [x] Local manual testing

### Manual Test Steps

1. Start the development server
2. Navigate to a non-existent route
3. Verify that the custom 404 page renders correctly
4. Verify responsiveness across screen sizes
5. Verify that the "Return to Command Center" button redirects properly

---

## Screenshot

<img width="1919" height="905" alt="Custom 404 Page" src="https://github.com/user-attachments/assets/b198717e-c53c-42e5-a2c0-bf878f287d2d" />

---

## AI Generation Declaration

* [x] Yes
* [ ] No

Used AI assistance for UI refinement.

---

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] My changes generate no new warnings
* [x] I am a GSSoC participant and I have been officially assigned to the linked issue by a mentor.
