### PR TITLE
fix: improve hero subtitle contrast for readability on dark background

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -437,7 +437,7 @@ export default function LandingPage() {
           <p
             style={{
               fontSize: 'clamp(14px, 2.5vw, 19px)',
-              color: 'var(--muted)',
+              color: '#94a3b8',
               maxWidth: 540,
               padding: '0 8px',
               margin: '24px auto 0',


### PR DESCRIPTION
## Description
The hero section subtitle text on the landing page had low contrast against the dark background, making it difficult to read — especially at reduced screen brightness. The subtitle "OpsCord ingests events from CircleCI, GitHub, Kubernetes & Datadog, then uses AI causality scoring to tell you exactly what broke — and why." was styled with `var(--muted)` which resolves to `#888888`, a mid-gray that fades significantly on dark backgrounds.

This fix changes the subtitle color to `#94a3b8` (Tailwind `slate-400`), a cool blue-gray that improves readability while fully preserving the dark industrial aesthetic and maintaining visual hierarchy below the main heading.

Fixes #18

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🎨 Style/Refactor (formatting, local variables, etc.)

## How Has This Been Tested?
- Opened the landing page locally at `http://localhost:3000`
- Verified subtitle readability at full and reduced screen brightness
- Confirmed the color fits the existing blue-gray palette without clashing with the heading gradient
- [x] Local manual testing (screenshot attached)
- [x] Unit Tests passing (`npm run test`)
- [x] Linters passing (`npm run lint`)
- [x] Type check passing (`npm run type-check`)

## AI Generation Declaration
- [ ] Yes
- [x] No

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I am a GSSoC participant and I have been officially assigned to the linked issue by a mentor.
<img width="1474" height="849" alt="Screenshot 2026-05-16 011354" src="https://github.com/user-attachments/assets/38405074-8518-48d9-b3f0-00b96e8aad31" />
<img width="1472" height="847" alt="Screenshot 2026-05-16 012518" src="https://github.com/user-attachments/assets/5f599c7d-b151-44e0-bb3f-d9d0c89b3ed4" />

