### PR TITLE
chore: add .editorconfig for consistent editor settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Description
Added .editorconfig to standardize editor settings across different IDEs. This prevents formatting inconsistencies when contributors use different editors.

## Type of Change
📝 Documentation update
## How Has This Been Tested?
Local manual testing - Verified config syntax is valid
Linters passing - No code changes

## Checklist:
- [ ✓] My code follows the style guidelines
- [ ✓] I have performed a self-review
- [ ✓] My changes generate no new warnings
- [ ✓] I am a GSSoC participant 
