### PR TITLE
fix: add error handling to /projects endpoint

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -23,11 +23,15 @@ app.get('/health', async (c) => {
 
 // Example route
 app.get('/projects', async (c) => {
-  const projects = await prisma.project.findMany();
-  return c.json({
-    success: true,
-    data: projects,
-  });
+  try {
+    const projects = await prisma.project.findMany();
+    return c.json({
+      success: true,
+      data: projects,
+    });
+  } catch (error) {
+    return c.json({ success: false, error: 'Failed to fetch projects' }, 500);
+  }
 });
 
 const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 4000;


### PR DESCRIPTION
## Description

The `/projects` endpoint didn’t have error handling, so it would crash if the database failed. Added a try-catch to return a proper 500 error response instead.

This keeps it consistent with the `/health` endpoint and improves API reliability.

## Type of Change

- [x] 🐛 Bug fix

## How Has This Been Tested

- [x] Matches existing `/health` error handling pattern  
- [x] No change in success response  

## Checklist

- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I am a GSSoC participant.
