### PR TITLE
fix: restore analyzer spinner animation

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -96,6 +96,12 @@ body {
   cursor:text ;
 }
 /* ── Keyframe Animations ───────────────── */
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 @keyframes pulse {
   0%,
   100% {
@@ -243,4 +249,3 @@ body {
   background: rgba(0, 112, 243, 0.3);
   color: #EDEDED;
 }
-

--- a/apps/web/components/ui/Skeleton.tsx
+++ b/apps/web/components/ui/Skeleton.tsx
@@ -2,14 +2,12 @@
 
 import React from 'react';
 
-interface SkeletonProps {
-  className?: string;
-}
+type SkeletonProps = React.HTMLAttributes<HTMLDivElement>;
 
 /**
  * Base skeleton block with pulse animation.
  * Use this to build more specific skeleton components.
  */
-export function Skeleton({ className = '' }: SkeletonProps) {
-  return <div className={`animate-pulse rounded bg-white/5 ${className}`} />;
+export function Skeleton({ className = '', ...props }: SkeletonProps) {
+  return <div className={`animate-pulse rounded bg-white/5 ${className}`} {...props} />;
 }


### PR DESCRIPTION
## Summary

- restore the missing global `@keyframes spin` animation used by the analyzer loading spinner
- allow the shared `Skeleton` div wrapper to accept normal HTML div props so existing analyzer chart skeletons can pass inline height styles

Fixes #36

## Root Cause

The analyzer spinner referenced `animation: spin ...`, but the app's global stylesheet did not define `@keyframes spin`, so the loading indicator could render without rotating. While validating the production build, TypeScript also exposed that `ChartSkeleton` passes `style` to `Skeleton`, but `Skeleton` only accepted `className`, which blocked a clean build.

## Changes Made

- added a global `@keyframes spin` rule in `apps/web/app/globals.css`
- widened `SkeletonProps` to `React.HTMLAttributes<HTMLDivElement>` and forwarded remaining props to the rendered div

## Testing

- `npm ci`
- `npm --workspace @opscord/web run build`
- `npm --workspace @opscord/web run type-check`
- `npm --workspace @opscord/web run start -- -p 3016`
- `curl -fsS http://localhost:3016/analyzer`
- fetched the built CSS asset from the production server and verified it includes `@keyframes spin`
- `git diff --check`

## Notes

- The build currently warns that `GEMINI_API_KEY` is not defined, but completes successfully.
- `npm ci` reports existing dependency audit warnings; this PR does not change dependencies.
- I also checked for the requested footer phrase `No spam. Only useful updates.` across the app and repository. It is not present in this codebase, so no speculative footer edit was made.
