### PR TITLE
fix: remove unused prisma import and fix blob content encoding

### DIFF
--- a/apps/ingestion/src/index.ts
+++ b/apps/ingestion/src/index.ts
@@ -1,7 +1,6 @@
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { logger } from 'hono/logger';
-import prisma from '@opscord/db';
 
 const app = new Hono().basePath('/api/v1/ingest');
 

--- a/apps/web/app/actions/createFixPr.ts
+++ b/apps/web/app/actions/createFixPr.ts
@@ -60,7 +60,7 @@ export async function createFixPr({
       const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/git/blobs`, {
         method: 'POST',
         headers,
-        body: JSON.stringify({ content, encoding: 'utf-8' }),
+        body: JSON.stringify({ content: btoa(content), encoding: 'base64' }),
       });
       if (!res.ok) throw new Error('Failed to upload blob');
       const data = await res.json();


### PR DESCRIPTION
1. Remove unused `prisma` import from ingestion service (causes build issues)
2. Fix blob content encoding to use base64 for reliable handling of all file content